### PR TITLE
Remove roles from list of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ baton resources
 
 - Users
 - Database Users
-- Roles
 - Projects
 - Teams
 - Organizations


### PR DESCRIPTION
As per my note in Slack, it looks like Roles was included in the readme by mistake, since Roles aren't synced. 