### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -12,6 +12,7 @@ type Mongodbatlas struct {
 	DeleteDatabaseUserWithReadOnly bool `mapstructure:"delete-database-user-with-read-only"`
 	MongoProxyHost string `mapstructure:"mongo-proxy-host"`
 	MongoProxyPort int `mapstructure:"mongo-proxy-port"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Mongodbatlas) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ var MongoProxyPort = field.IntField(
 var BaseURLField = field.StringField(
 	"base-url",
 	field.WithDescription("Override the MongoDB Atlas API URL (for testing)"),
+	field.WithHidden(true),
 )
 
 //go:generate go run ./gen

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,7 @@ var BaseURLField = field.StringField(
 	"base-url",
 	field.WithDescription("Override the MongoDB Atlas API URL (for testing)"),
 	field.WithHidden(true),
+	field.WithExportTarget(field.ExportTargetCLIOnly),
 )
 
 //go:generate go run ./gen

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,11 @@ var MongoProxyPort = field.IntField(
 	field.WithExportTarget(field.ExportTargetOps),
 )
 
+var BaseURLField = field.StringField(
+	"base-url",
+	field.WithDescription("Override the MongoDB Atlas API URL (for testing)"),
+)
+
 //go:generate go run ./gen
 var Config = field.NewConfiguration(
 	[]field.SchemaField{
@@ -75,6 +80,8 @@ var Config = field.NewConfiguration(
 		// Proxy fields
 		MongoProxyHost,
 		MongoProxyPort,
+		// Testing
+		BaseURLField,
 	},
 	field.WithConnectorDisplayName("MongoDB Atlas"),
 	field.WithHelpUrl("/docs/baton/mongodb-atlas"),

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -209,6 +209,10 @@ func New(ctx context.Context, config *cfg.Mongodbatlas, opts *cli.ConnectorOpts)
 		clientModifiers = append(clientModifiers, admin.UseDigestAuth(config.PublicKey, config.PrivateKey))
 	}
 
+	if config.BaseUrl != "" {
+		clientModifiers = append(clientModifiers, admin.UseBaseURL(config.BaseUrl))
+	}
+
 	client, err := admin.NewClient(clientModifiers...)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/connector/database.go
+++ b/pkg/connector/database.go
@@ -22,11 +22,15 @@ import (
 	"go.mongodb.org/atlas-sdk/v20250312006/admin"
 )
 
+const (
+	roleRead = "read"
+)
+
 // Const roles for db https://www.mongodb.com/docs/atlas/mongodb-users-roles-and-privileges/#std-label-atlas-user-privileges
 // Only that uses DB.
 var dbRoles = []string{
 	"dbAdmin",   // Only db
-	"read",      // DB and collections
+	roleRead,    // DB and collections
 	"readWrite", // DB and collections
 }
 
@@ -398,7 +402,7 @@ func (o *databaseBuilder) shouldDeleteUser(roles []admin.DatabaseUserRole) bool 
 			return false
 		}
 
-		if roles[0].RoleName == "read" && roles[0].DatabaseName == "admin" {
+		if roles[0].RoleName == roleRead && roles[0].DatabaseName == "admin" {
 			return true
 		}
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -304,7 +304,7 @@ func (o *userBuilder) CreateAccount(ctx context.Context, accountInfo *v2.Account
 		Roles: &[]admin.DatabaseUserRole{
 			{
 				DatabaseName: databaseNameAdmin,
-				RoleName:     "read",
+				RoleName:     roleRead,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-mongodb-atlas/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-mongodb-atlas --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.