### PR TITLE
[CXP-456] Fix mongo connect retries and error propagation

### DIFF
--- a/pkg/connector/database.go
+++ b/pkg/connector/database.go
@@ -106,9 +106,12 @@ func (o *databaseBuilder) List(ctx context.Context, parentResourceID *v2.Resourc
 
 		_, mongoDriver, err := o.mongodriver.Connect(ctx, groupID, clusterName)
 		if err != nil {
-			l.Error("failed to connect to MongoDB Atlas cluster skipping database sync", zap.String("group_id", groupID), zap.String("cluster_name", clusterName), zap.Error(err))
-			// We are skipping databases if we can't connect to the cluster.
-			return nil, nil, nil
+			l.Error("failed to connect to MongoDB Atlas cluster", zap.String("group_id", groupID), zap.String("cluster_name", clusterName), zap.Error(err))
+			// Propagate the error so the baton-sdk syncer sees codes.Unavailable and
+			// retries, and so the underlying cause (e.g. IP access list / unreachable
+			// cluster) surfaces in the sync-lifecycle error instead of silently
+			// returning zero databases.
+			return nil, nil, fmt.Errorf("failed to connect to MongoDB Atlas cluster: %w", err)
 		}
 
 		names, err := mongoDriver.ListDatabaseNames(ctx, bson.M{}, &options.ListDatabasesOptions{

--- a/pkg/connector/database.go
+++ b/pkg/connector/database.go
@@ -107,10 +107,10 @@ func (o *databaseBuilder) List(ctx context.Context, parentResourceID *v2.Resourc
 		_, mongoDriver, err := o.mongodriver.Connect(ctx, groupID, clusterName)
 		if err != nil {
 			l.Error("failed to connect to MongoDB Atlas cluster", zap.String("group_id", groupID), zap.String("cluster_name", clusterName), zap.Error(err))
-			// Propagate the error so the baton-sdk syncer sees codes.Unavailable and
-			// retries, and so the underlying cause (e.g. IP access list / unreachable
-			// cluster) surfaces in the sync-lifecycle error instead of silently
-			// returning zero databases.
+			// Propagate the error so the underlying cause (e.g. IP access list /
+			// unreachable cluster) surfaces in the sync-lifecycle error instead of
+			// silently returning zero databases. Connect() returns codes.NotFound
+			// after exhausting its internal retries, which the SDK does not retry.
 			return nil, nil, fmt.Errorf("failed to connect to MongoDB Atlas cluster: %w", err)
 		}
 

--- a/pkg/connector/mongodriver/mongo_driver.go
+++ b/pkg/connector/mongodriver/mongo_driver.go
@@ -199,7 +199,11 @@ func (m *MongoDriver) Connect(ctx context.Context, groupID, clusterName string) 
 				zap.String("cluster_name", clusterName),
 			)
 			lastErr = err
-			time.Sleep(time.Second * 2)
+			select {
+			case <-time.After(time.Second * 2):
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			}
 			continue
 		}
 
@@ -213,7 +217,11 @@ func (m *MongoDriver) Connect(ctx context.Context, groupID, clusterName string) 
 				zap.String("cluster_name", clusterName),
 			)
 			lastErr = err
-			time.Sleep(time.Second * 2)
+			select {
+			case <-time.After(time.Second * 2):
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			}
 			continue
 		}
 

--- a/pkg/connector/mongodriver/mongo_driver.go
+++ b/pkg/connector/mongodriver/mongo_driver.go
@@ -162,59 +162,73 @@ func (m *MongoDriver) Connect(ctx context.Context, groupID, clusterName string) 
 		)
 	}
 
-	l.Info(
-		"Connecting to MongoDB",
-		zap.String("cluster_name", clusterName),
-		zap.String("scheme", connStr.scheme),
-	)
+	const maxAttempts = 3
+	var lastErr error
 
-	opts := options.Client().
-		ApplyURI(uri).
-		SetMaxConnIdleTime(60 * time.Second).
-		SetMaxPoolSize(10)
-
-	if dialer != nil {
-		opts.SetDialer(dialer)
-		// Increase timeouts when using SOCKS5 proxy since connections take longer:
-		// proxy connect -> SOCKS5 handshake -> proxy connects to MongoDB -> TLS handshake
-		opts.SetConnectTimeout(60 * time.Second)
-		opts.SetServerSelectionTimeout(60 * time.Second)
-	}
-
-	// Single attempt: delegate retries to the baton-sdk syncer by returning
-	// codes.Unavailable on transient failures. The SDK retries ListResources /
-	// ListEntitlements / ListGrants calls with linear backoff, giving us fresh
-	// attempts with clean timeout budgets (particularly important in Lambda mode).
-	client, err := mongo.Connect(ctx, opts)
-	if err != nil {
-		l.Error(
-			"Failed to connect to MongoDB",
-			zap.Error(err),
+	for i := 0; i < maxAttempts; i++ {
+		l.Info(
+			"Connecting to MongoDB",
+			zap.Int("attempt", i+1),
 			zap.String("cluster_name", clusterName),
+			zap.String("scheme", connStr.scheme),
 		)
-		return nil, nil, status.Errorf(codes.Unavailable,
-			"mongo.Connect failed for cluster %q: %v", clusterName, err)
-	}
 
-	if err = client.Ping(ctx, nil); err != nil {
-		_ = client.Disconnect(ctx)
-		l.Error(
-			"Failed to ping MongoDB",
-			zap.Error(err),
+		opts := options.Client().
+			ApplyURI(uri).
+			SetMaxConnIdleTime(60 * time.Second).
+			SetMaxPoolSize(10)
+
+		if dialer != nil {
+			opts.SetDialer(dialer)
+			// Increase timeouts when using SOCKS5 proxy since connections take longer:
+			// proxy connect -> SOCKS5 handshake -> proxy connects to MongoDB -> TLS handshake
+			opts.SetConnectTimeout(60 * time.Second)
+			opts.SetServerSelectionTimeout(60 * time.Second)
+		}
+
+		client, err := mongo.Connect(ctx, opts)
+		if err != nil {
+			l.Error(
+				"Failed to connect to MongoDB",
+				zap.Error(err),
+				zap.Int("attempt", i+1),
+				zap.String("cluster_name", clusterName),
+			)
+			lastErr = err
+			time.Sleep(time.Second * 2)
+			continue
+		}
+
+		if err = client.Ping(ctx, nil); err != nil {
+			_ = client.Disconnect(ctx)
+			l.Error(
+				"Failed to ping MongoDB",
+				zap.Error(err),
+				zap.Int("attempt", i+1),
+				zap.String("username", accountTuple.user.Username),
+				zap.String("cluster_name", clusterName),
+			)
+			lastErr = err
+			time.Sleep(time.Second * 2)
+			continue
+		}
+
+		l.Info(
+			"Successfully connected to MongoDB",
+			zap.String("cluster_name", clusterName),
 			zap.String("username", accountTuple.user.Username),
-			zap.String("cluster_name", clusterName),
+			zap.Int("attempts", i+1),
 		)
-		return nil, nil, status.Errorf(codes.Unavailable,
-			"MongoDB cluster %q unreachable: %v", clusterName, err)
+		m.clients[clientKey] = client
+		return accountTuple.user, client, nil
 	}
 
-	l.Info(
-		"Successfully connected to MongoDB",
-		zap.String("cluster_name", clusterName),
-		zap.String("username", accountTuple.user.Username),
-	)
-	m.clients[clientKey] = client
-	return accountTuple.user, client, nil
+	// Exhausted retries — likely a configuration issue (IP access list,
+	// PrivateLink, paused cluster). Return codes.NotFound so the baton-sdk
+	// syncer does NOT retry, and the error surfaces on the sync lifecycle.
+	return nil, nil, status.Errorf(codes.NotFound,
+		"failed to connect to MongoDB cluster %q after %d attempts: %v",
+		clusterName, maxAttempts, lastErr)
 }
 
 type connectionInfo struct {

--- a/pkg/connector/mongodriver/mongo_driver.go
+++ b/pkg/connector/mongodriver/mongo_driver.go
@@ -130,7 +130,11 @@ func (m *MongoDriver) Connect(ctx context.Context, groupID, clusterName string) 
 		m.accountsPerGroupId[groupID] = accountTuple
 		// Give Atlas a moment to propagate the newly-created user before first use.
 		// Only needed after creation; cache hits above skip this.
-		time.Sleep(time.Second * 5)
+		select {
+		case <-time.After(time.Second * 5):
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
 	}
 
 	clientKey := fmt.Sprintf("%s-%s", groupID, clusterName)

--- a/pkg/connector/mongodriver/mongo_driver.go
+++ b/pkg/connector/mongodriver/mongo_driver.go
@@ -11,6 +11,8 @@ import (
 	"github.com/conductorone/baton-mongodb-atlas/pkg/connector/mongoconfig"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/crypto"
@@ -126,15 +128,15 @@ func (m *MongoDriver) Connect(ctx context.Context, groupID, clusterName string) 
 			pass: password,
 		}
 		m.accountsPerGroupId[groupID] = accountTuple
+		// Give Atlas a moment to propagate the newly-created user before first use.
+		// Only needed after creation; cache hits above skip this.
+		time.Sleep(time.Second * 5)
 	}
 
 	clientKey := fmt.Sprintf("%s-%s", groupID, clusterName)
-	client, ok := m.clients[clientKey]
-	if ok {
+	if client, ok := m.clients[clientKey]; ok {
 		return accountTuple.user, client, nil
 	}
-
-	time.Sleep(time.Second * 5) // Wait for the user to be fully created and available
 
 	connStr, err := m.connectionString(ctx, groupID, clusterName)
 	if err != nil {
@@ -160,68 +162,59 @@ func (m *MongoDriver) Connect(ctx context.Context, groupID, clusterName string) 
 		)
 	}
 
-	for i := 0; i < 10; i++ {
-		l.Info(
-			"Trying to connect to MongoDB",
-			zap.Int("attempt", i+1),
-			zap.String("cluster_name", clusterName),
-			zap.String("scheme", connStr.scheme),
-		)
+	l.Info(
+		"Connecting to MongoDB",
+		zap.String("cluster_name", clusterName),
+		zap.String("scheme", connStr.scheme),
+	)
 
-		opts := options.Client().
-			ApplyURI(uri).
-			SetMaxConnIdleTime(60 * time.Second).
-			SetMaxPoolSize(10)
+	opts := options.Client().
+		ApplyURI(uri).
+		SetMaxConnIdleTime(60 * time.Second).
+		SetMaxPoolSize(10)
 
-		if dialer != nil {
-			opts.SetDialer(dialer)
-			// Increase timeouts when using SOCKS5 proxy since connections take longer:
-			// proxy connect -> SOCKS5 handshake -> proxy connects to MongoDB -> TLS handshake
-			opts.SetConnectTimeout(60 * time.Second)
-			opts.SetServerSelectionTimeout(60 * time.Second)
-		}
-
-		client, err := mongo.Connect(ctx, opts)
-		if err != nil {
-			l.Error(
-				"Failed to connect to MongoDB",
-				zap.Error(err),
-				zap.Int("attempt", i+1),
-				zap.String("cluster_name", clusterName),
-			)
-			time.Sleep(time.Second * 2) // Retry after a delay
-			continue
-		}
-
-		if err = client.Ping(ctx, nil); err != nil {
-			_ = client.Disconnect(ctx)
-			l.Error(
-				"Failed to ping MongoDB",
-				zap.Error(err),
-				zap.Int("attempt", i+1),
-				zap.String("username", accountTuple.user.Username),
-				zap.String("cluster_name", clusterName),
-			)
-			time.Sleep(time.Second * 2) // Retry after a delay
-			continue
-		}
-
-		l.Info(
-			"Successfully connected to MongoDB",
-			zap.String("cluster_name", clusterName),
-			zap.String("username", accountTuple.user.Username),
-			zap.Int("attempts", i+1),
-		)
-		m.clients[clientKey] = client
-		return accountTuple.user, client, nil
+	if dialer != nil {
+		opts.SetDialer(dialer)
+		// Increase timeouts when using SOCKS5 proxy since connections take longer:
+		// proxy connect -> SOCKS5 handshake -> proxy connects to MongoDB -> TLS handshake
+		opts.SetConnectTimeout(60 * time.Second)
+		opts.SetServerSelectionTimeout(60 * time.Second)
 	}
 
-	l.Error(
-		"Failed to connect to MongoDB after multiple attempts",
+	// Single attempt: delegate retries to the baton-sdk syncer by returning
+	// codes.Unavailable on transient failures. The SDK retries ListResources /
+	// ListEntitlements / ListGrants calls with linear backoff, giving us fresh
+	// attempts with clean timeout budgets (particularly important in Lambda mode).
+	client, err := mongo.Connect(ctx, opts)
+	if err != nil {
+		l.Error(
+			"Failed to connect to MongoDB",
+			zap.Error(err),
+			zap.String("cluster_name", clusterName),
+		)
+		return nil, nil, status.Errorf(codes.Unavailable,
+			"mongo.Connect failed for cluster %q: %v", clusterName, err)
+	}
+
+	if err = client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(ctx)
+		l.Error(
+			"Failed to ping MongoDB",
+			zap.Error(err),
+			zap.String("username", accountTuple.user.Username),
+			zap.String("cluster_name", clusterName),
+		)
+		return nil, nil, status.Errorf(codes.Unavailable,
+			"MongoDB cluster %q unreachable: %v", clusterName, err)
+	}
+
+	l.Info(
+		"Successfully connected to MongoDB",
 		zap.String("cluster_name", clusterName),
-		zap.Int("max_attempts", 10),
+		zap.String("username", accountTuple.user.Username),
 	)
-	return nil, nil, fmt.Errorf("failed to connect to MongoDB after multiple attempts")
+	m.clients[clientKey] = client
+	return accountTuple.user, client, nil
 }
 
 type connectionInfo struct {


### PR DESCRIPTION
## Summary

Fixes a silent sync-failure mode for mongodb-atlas connectors, particularly on Lambda deployments.

- **3-attempt retry loop** (down from 10) for MongoDB Connect + Ping. Covers transient failures while fitting within the 5-min Lambda timeout budget.
- **`codes.NotFound` after retry exhaustion** so the baton-sdk syncer does NOT retry indefinitely. A misconfigured cluster (IP access list, PrivateLink, paused) fails fast with an actionable error message instead of spinning up hundreds of Lambda invocations against an unreachable target.
- **Error message includes the underlying cause** — e.g. `failed to connect to MongoDB cluster "<name>" after 3 attempts: server selection timeout, current topology: { Type: ReplicaSetNoPrimary ... }` — so support can identify the problem.
- **`database.go`: propagate Connect errors** instead of silently returning zero databases with `return nil, nil, nil`.
- **Move 5s post-createUser sleep** inside the `createUser` branch so it only runs after provisioning a new ephemeral user, not on every cache-hit Connect call.

### Background

Investigated via Datadog for an affected tenant whose connector had **zero successful syncs since Lambda was enabled**. The old 10-retry loop was dead code: at the 60s Lambda timeout, the first ping's `ServerSelectionTimeout` alone exceeded the budget, killing the container mid-first-iteration (`attempt=1` on every log, 2100+ over 7 days). The tenant only saw `lambda_transport: function timed out: Unhandled` with no hint it was a MongoDB connectivity problem.

See [CXP-456](https://linear.app/ductone/issue/CXP-456) for full investigation details including affected tenants and Datadog links.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass locally
- [x] Deployed to affected connector — verified in Datadog:
  - Ping errors show `attempt=1,2,3` (retry loop completing all 3 iterations)
  - No `connector_lambda: function returned error` with `DeadlineExceeded: Unhandled`
  - Sync lifecycle errors out with actionable message after 3 attempts
  - SDK does NOT retry after `codes.NotFound` — connector goes quiet until next scheduled sync
- [ ] Smoke-test against a healthy Atlas cluster: sync completes, client cached
- [ ] Verify service mode (self-hosted): client cache persists across syncs, no unnecessary `createUser` or 5s sleep

## References

- Linear: [CXP-456](https://linear.app/ductone/issue/CXP-456)