### PR TITLE
docs: clarify SCRAM-SHA username must be alphanumeric

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -44,7 +44,7 @@ The **Authentication Type** field determines how the provisioned database user a
 
 | Authentication type | Description | Username format |
 | :--- | :--- | :--- |
-| `SCRAM-SHA` | Password-based authentication (default). A random password is generated and stored in a C1 [vault](/product/admin/vaults). | Any string |
+| `SCRAM-SHA` | Password-based authentication (default). A random password is generated and stored in a C1 [vault](/product/admin/vaults). | Alphanumeric string (special characters such as `@` are not supported; email addresses are invalid) |
 | `AWS_IAM_USER` | AWS IAM user authentication. | AWS user ARN |
 | `X509_CUSTOMER` | Customer-managed X.509 certificate authentication. | RFC 2253 Distinguished Name |
 | `X509_MANAGED` | MongoDB Atlas-managed X.509 certificate authentication. | RFC 2253 Distinguished Name |


### PR DESCRIPTION
## Summary

- Updates the `SCRAM-SHA` username format in the authentication types table in `docs/connector.mdx` from `Any string` to `Alphanumeric string (special characters such as \`@\` are not supported; email addresses are invalid)`
- MongoDB Atlas rejects any username containing non-alphanumeric characters (e.g. `@`, `.`) for SCRAM-SHA users with `ATLAS_INVALID_USERNAME`
- Constraint sourced from the Atlas Admin API OpenAPI spec (`CloudDatabaseUser.username`: "Alphanumeric string" for SCRAM-SHA)

Closes CXH-1401

## Test plan

- [ ] Verify the authentication types table renders correctly in the docs
- [ ] Confirm the SCRAM-SHA username format description matches MongoDB Atlas behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)