### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -110,7 +110,7 @@ Carefully copy and save the public key and private key.
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the MongoDB Atlas connector
 
@@ -175,7 +175,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your MongoDB Atlas connector is now pulling access data into C1.
+**Done.** Your MongoDB Atlas connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -307,7 +307,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your MongoDB Atlas connector is now pulling access data into C1.
+**Done.** Your MongoDB Atlas connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site.

- Restore `**Done.**` closing phrase (replaces `**That's it!**`) — 3 instances

These corrections prevent the sync bot from reintroducing regressions on future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)